### PR TITLE
Add tests for language switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.mo
 __pycache__/
+instance/

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,7 +17,8 @@ def create_app(test_config=None):
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.secret_key = 'change-me'
     app.config.setdefault('BABEL_DEFAULT_LOCALE', 'en')
-    app.config.setdefault('BABEL_TRANSLATION_DIRECTORIES', 'translations')
+    default_trans_dir = Path(__file__).resolve().parent.parent / 'translations'
+    app.config.setdefault('BABEL_TRANSLATION_DIRECTORIES', str(default_trans_dir))
 
     trans_dir = app.config['BABEL_TRANSLATION_DIRECTORIES']
     po_files = list(Path(trans_dir).rglob('*.po'))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,12 @@
+import os
+import sys
 import pytest
+import werkzeug
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from app import create_app, db
 from app.models import Article
-import werkzeug
 
 @pytest.fixture(autouse=True)
 def _ensure_version():
@@ -73,3 +78,27 @@ def test_api_create_article_invalid_numbers(client):
     data = resp.get_json()
     assert data['meme_potential'] is None
     assert data['reality_disruption'] is None
+
+
+def test_language_switch_to_russian(client):
+    resp = client.get('/?lang=ru')
+    assert resp.status_code == 200
+    body = resp.data.decode('utf-8')
+    assert 'Гениально-инвертированная Вики' in body
+
+    resp = client.get('/')
+    body = resp.data.decode('utf-8')
+    assert 'Гениально-инвертированная Вики' in body
+
+
+def test_language_switch_back_to_english(client):
+    client.get('/?lang=ru')
+
+    resp = client.get('/?lang=en')
+    assert resp.status_code == 200
+    body = resp.data.decode('utf-8')
+    assert 'Genius Inverted Wiki' in body
+
+    resp = client.get('/')
+    body = resp.data.decode('utf-8')
+    assert 'Genius Inverted Wiki' in body


### PR DESCRIPTION
## Summary
- cover Flask app root with locale switch tests
- adjust translation directory resolution so compiled messages load
- ignore test DB directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841af82a4f883329e28c10a1b8cce6c