### PR TITLE
Add Swagger docs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, session
 from flask_babel import Babel
+from flasgger import Swagger
 from pathlib import Path
 import subprocess
 from flask_sqlalchemy import SQLAlchemy
@@ -30,6 +31,7 @@ def create_app(test_config=None):
 
     db.init_app(app)
     migrate.init_app(app, db)
+    Swagger(app, config={"specs_route": "/swagger"}, merge=True)
 
     def get_locale() -> str:
         lang = request.args.get('lang')

--- a/app/api.py
+++ b/app/api.py
@@ -6,16 +6,52 @@ bp = Blueprint('api', __name__)
 
 @bp.route('/articles')
 def list_articles():
+    """List all articles
+    ---
+    responses:
+      200:
+        description: Returns a list of articles
+    """
     articles = Article.query.all()
     return jsonify([serialize_article(a) for a in articles])
 
 @bp.route('/articles/<int:article_id>')
 def get_article(article_id):
+    """Retrieve an article by id
+    ---
+    parameters:
+      - name: article_id
+        in: path
+        type: integer
+        required: true
+    responses:
+      200:
+        description: The requested article
+    """
     article = Article.query.get_or_404(article_id)
     return jsonify(serialize_article(article))
 
 @bp.route('/articles', methods=['POST'])
 def create_article():
+    """Create a new article
+    ---
+    consumes:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: object
+          properties:
+            title:
+              type: string
+            content:
+              type: string
+    responses:
+      201:
+        description: Article created
+    """
     data = request.get_json()
     if not data or 'title' not in data or 'content' not in data:
         abort(400)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,7 +10,8 @@
     <a href="/article/new">{{ _('New Article') }}</a>
     <span class="float-end">
         <a href="?lang=en">EN</a> |
-        <a href="?lang=ru">RU</a>
+        <a href="?lang=ru">RU</a> |
+        <a href="/swagger">Swagger</a>
     </span>
 </nav>
 <hr>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.3.2
 Flask-SQLAlchemy==3.0.3
 Flask-Migrate==4.0.4
 Flask-Babel==3.1.0
+flasgger==0.9.7.1


### PR DESCRIPTION
## Summary
- integrate flasgger Swagger generator
- expose docs at `/swagger`
- document API endpoints
- link Swagger page in nav

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b72a4118833293da6153fa170552