### PR TITLE
Add articles list with alphabet filter

### DIFF
--- a/app/templates/articles.html
+++ b/app/templates/articles.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ _('All Articles') }}</h1>
+<div class="mb-2">
+  {% for row in alphabet_rows %}
+  <div>
+    {% for ch in row %}
+      <a href="{{ url_for('web.list_articles', letter=ch) }}">{{ ch }}</a>
+      {% if not loop.last %}|{% endif %}
+    {% endfor %}
+  </div>
+  {% endfor %}
+</div>
+<hr>
+<div class="text-end mb-2">
+  {% if page > 1 %}
+    <a href="{{ url_for('web.list_articles', page=page-1, letter=letter) }}">&laquo; Prev</a>
+  {% endif %}
+  <span> {{ page }} / {{ total_pages }} </span>
+  {% if page < total_pages %}
+    <a href="{{ url_for('web.list_articles', page=page+1, letter=letter) }}">Next &raquo;</a>
+  {% endif %}
+</div>
+<ul>
+{% for art in articles %}
+  <li><a href="/article/{{ art.id }}">{{ art.title }}</a></li>
+{% endfor %}
+</ul>
+<div class="text-end mt-2">
+  {% if page > 1 %}
+    <a href="{{ url_for('web.list_articles', page=page-1, letter=letter) }}">&laquo; Prev</a>
+  {% endif %}
+  <span> {{ page }} / {{ total_pages }} </span>
+  {% if page < total_pages %}
+    <a href="{{ url_for('web.list_articles', page=page+1, letter=letter) }}">Next &raquo;</a>
+  {% endif %}
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,7 +10,8 @@
 </a>
 <nav>
     <a href="/">{{ _('Home') }}</a> |
-    <a href="/article/new">{{ _('New Article') }}</a>
+    <a href="/article/new">{{ _('New Article') }}</a> |
+    <a href="/articles">{{ _('All Articles') }}</a>
     <span class="float-end">
         <a href="?lang=en">EN</a> |
         <a href="?lang=ru">RU</a> |

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -102,3 +102,23 @@ def test_language_switch_back_to_english(client):
     resp = client.get('/')
     body = resp.data.decode('utf-8')
     assert 'Genius Inverted Wiki' in body
+
+
+def test_list_articles_and_filter(client):
+    titles = ['Alpha', 'Banana', 'Груша', '1Test']
+    with client.application.app_context():
+        for t in titles:
+            db.session.add(Article(title=t, content='c'))
+        db.session.commit()
+
+    resp = client.get('/articles')
+    assert resp.status_code == 200
+    body = resp.data.decode('utf-8')
+    assert 'Alpha' in body
+    assert 'Banana' in body
+
+    resp = client.get('/articles?letter=A')
+    body = resp.data.decode('utf-8')
+    assert 'Alpha' in body
+    assert 'Banana' not in body
+

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -12,6 +12,9 @@ msgstr "Home"
 msgid "New Article"
 msgstr "New Article"
 
+msgid "All Articles"
+msgstr "All Articles"
+
 msgid "Random article:"
 msgstr "Random article:"
 

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -12,6 +12,9 @@ msgstr "Главная"
 msgid "New Article"
 msgstr "Новая статья"
 
+msgid "All Articles"
+msgstr "Все статьи"
+
 msgid "Random article:"
 msgstr "Случайная статья:"
 


### PR DESCRIPTION
## Summary
- add paginated article list with alphabet filtering
- link list to navigation menu
- localize new menu item
- test article list functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bd7562e48332b98a4c4e1b269a2c